### PR TITLE
remove unused imports from Device::SerialPort

### DIFF
--- a/lib/Device/CurrentCost.pm
+++ b/lib/Device/CurrentCost.pm
@@ -47,7 +47,7 @@ use constant DEBUG => $ENV{DEVICE_CURRENT_COST_DEBUG};
 use Carp qw/croak carp/;
 use Device::CurrentCost::Constants;
 use Device::CurrentCost::Message;
-use Device::SerialPort qw/:PARAM :STAT 0.07/;
+use Device::SerialPort;
 use Fcntl;
 use IO::Handle;
 use IO::Select;


### PR DESCRIPTION
This module doesn't use any of the constants or functions from Device::SerialPort, so there is no need to import them.

Additionally, the tests use a mock version of the module, which doesn't provide any of those imports. If any were used, there would be errors from the test not providing them.

When using the mock module, the unhandled arguments were just ignored by perl. Future versions of perl are intending to throw errors when arguments are passed to an undefined import methd.